### PR TITLE
Set Jupyter version to Java 8

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,14 +3,14 @@ object Versions {
     const val groupID = "org.jetbrains.kotlinx.spark"
     const val kotlin = "1.8.0"
     const val jvmTarget = "8"
-    const val jupyterJvmTarget = "11"
+    const val jupyterJvmTarget = "8"
 
     inline val spark get() = System.getProperty("spark") as String
     inline val scala get() = System.getProperty("scala") as String
     inline val sparkMinor get() = spark.substringBeforeLast('.')
     inline val scalaCompat get() = scala.substringBeforeLast('.')
 
-    const val jupyter = "0.11.0-210"
+    const val jupyter = "0.12.0-32-1"
     const val kotest = "5.5.4"
     const val kotestTestContainers = "1.3.3"
     const val dokka = "1.7.10"

--- a/jupyter/src/test/kotlin/org/jetbrains/kotlinx/spark/api/jupyter/JupyterTests.kt
+++ b/jupyter/src/test/kotlin/org/jetbrains/kotlinx/spark/api/jupyter/JupyterTests.kt
@@ -59,6 +59,7 @@ class JupyterTests : ShouldSpec({
                 librariesScanner.addLibrariesFromClassLoader(
                     classLoader = currentClassLoader,
                     host = this,
+                    notebook = notebook,
                     integrationTypeNameRules = listOf(
                         PatternNameAcceptanceRule(
                             acceptsFlag = false,
@@ -341,6 +342,7 @@ class JupyterStreamingTests : ShouldSpec({
                 librariesScanner.addLibrariesFromClassLoader(
                     classLoader = currentClassLoader,
                     host = this,
+                    notebook = notebook,
                     integrationTypeNameRules = listOf(
                         PatternNameAcceptanceRule(
                             acceptsFlag = false,


### PR DESCRIPTION
Fixes https://github.com/Kotlin/kotlin-spark-api/issues/199.

Seems that the Kotlin Jupyter API has been updated to support Java 8 since the last time I checked :) This PR makes it so our integration module is downgraded to Java 8 as well.