### PR TITLE
Version bumps

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -19,7 +19,7 @@ object Versions {
     const val atrium = "0.17.0"
     const val licenseGradlePluginVersion = "0.15.0"
     const val kafkaStreamsTestUtils = "3.1.0"
-    const val hadoop = "3.3.2"
+    const val hadoop = "3.3.1"
     const val kotlinxHtml = "0.7.5"
     const val klaxon = "5.5"
     const val jacksonDatabind = "2.13.4.2"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,7 +13,7 @@ object Versions {
     const val jupyter = "0.12.0-32-1"
     const val kotest = "5.5.4"
     const val kotestTestContainers = "1.3.3"
-    const val dokka = "1.8.10"
+    const val dokka = "1.8.20"
     const val jcp = "7.0.5"
     const val mavenPublish = "0.20.0"
     const val atrium = "0.17.0"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val project = "1.2.4-SNAPSHOT"
     const val groupID = "org.jetbrains.kotlinx.spark"
-    const val kotlin = "1.9.0"
+    const val kotlin = "1.8.20"
     const val jvmTarget = "8"
     const val jupyterJvmTarget = "8"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -19,7 +19,7 @@ object Versions {
     const val atrium = "0.17.0"
     const val licenseGradlePluginVersion = "0.15.0"
     const val kafkaStreamsTestUtils = "3.1.0"
-    const val hadoop = "3.3.1"
+    const val hadoop = "3.3.6"
     const val kotlinxHtml = "0.7.5"
     const val klaxon = "5.5"
     const val jacksonDatabind = "2.13.4.2"


### PR DESCRIPTION
looks like kotlin 1.9.0 still causes issues, but bumps to 1.8.20 are fine